### PR TITLE
fix: missing HAL_PWR_DisableBkUpAccess in HAL_RCCEx_PeriphCLKConfig

### DIFF
--- a/Src/stm32wlxx_hal_rcc_ex.c
+++ b/Src/stm32wlxx_hal_rcc_ex.c
@@ -193,6 +193,9 @@ HAL_StatusTypeDef HAL_RCCEx_PeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *PeriphClk
       status = ret;
     }
 
+    /* Disable write access to Backup domain */
+    HAL_PWR_DisableBkUpAccess();
+
   }
 
   /*-------------------- USART1 clock source configuration -------------------*/


### PR DESCRIPTION
missing `HAL_PWR_DisableBkUpAccess` in `HAL_RCCEx_PeriphCLKConfig` will result writing arbitrary data to RTC backup register when execute `__HAL_RCC_RTCAPB_CLK_ENABLE`